### PR TITLE
Adds heuristic to resolve manufacturer

### DIFF
--- a/profiler2/constants.py
+++ b/profiler2/constants.py
@@ -53,6 +53,7 @@ FT_CAPABILITIES_TAG = 54  # 802.11r - mobility domain (MDE) IE
 RM_CAPABILITIES_TAG = 70  # 802.11k
 EXT_CAPABILITIES_TAG = 127  # 802.11v - Extended Capabilities
 VHT_CAPABILITIES_TAG = 191  # 802.11ac
+VENDOR_SPECIFIC_IE_TAG = 221  # Vendor Specific IE
 EXT_IE_TAG = 255  # Element ID Extension field
 
 CHANNELS = [

--- a/profiler2/profiler.py
+++ b/profiler2/profiler.py
@@ -320,6 +320,8 @@ class Profiler(object):
                     )
                     oui_manuf_vendor = lookup.get_manuf(vendor_mac)
                     if oui_manuf_vendor is not None:
+                        # Apple vendor specific IEs can only be found in Apple devices
+                        # (no other OUIs are considered at the moment)
                         if oui_manuf_vendor.startswith("Apple"):
                             oui_manuf = oui_manuf_vendor
 


### PR DESCRIPTION
If the manufacturer cannot be resolved by looking up the client's MAC in the manuf database, then we look into the vendor specific IEs for additional OUIs we can use to try to resolve the manufacturer. 

Only vendor specific IEs that we know are advertised exclusively by the client's manufacturer should be considered. For example, Apple vendor specific IEs are only advertised by Apple devices.